### PR TITLE
Fix syntax error.

### DIFF
--- a/rpm/SPECS/openmodelica.spec.tpl
+++ b/rpm/SPECS/openmodelica.spec.tpl
@@ -105,7 +105,7 @@ BuildRequires: qt5-qtxmlpatterns-devel
 BuildRequires: devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran
 %define devtoolsconfigureflags CC=/opt/rh/devtoolset-8/root/usr/bin/gcc CXX=/opt/rh/devtoolset-8/root/usr/bin/g++ FC=/opt/rh/devtoolset-8/root/usr/bin/gfortran
 %endif
-%if 0%{?rhel} = 7
+%if 0%{?rhel} == 7
 %define cmakecommand CMAKE=cmake3
 %endif
 


### PR DESCRIPTION
Fix syntax error.

  - Change '=' to '=='.

  - It should also probably be
      `%if 0%{?rhel} <= 7`
    instead of
      `%if 0%{?rhel} == 7`
    To cover older versions as well.

  - For now getting el7 working again is enough.