### PR TITLE
Require recent libarchive.

### DIFF
--- a/rpm/SPECS/openmodelica.spec.tpl
+++ b/rpm/SPECS/openmodelica.spec.tpl
@@ -97,6 +97,13 @@ BuildRequires: cmake
 %define cmakecommand CMAKE=cmake
 %endif
 
+# The base centos:8 image (we use for our build-deps:el8 image) comes with
+# broken cmake package due to old libarchive (v3.3.2). v3.3.3 Seems to work.
+# Once the base image is updated this can be removed.
+%if 0%{?rhel} == 8
+Requires: libarchive >= 3.3.3
+%endif
+
 # EL6 has -static-libstdc++ inside devtools (but the system g++ doesn't know the flag)
 %{?el6:Requires: devtoolset-8-gcc}
 %{?el6:Requires: devtoolset-8-gcc-c++}


### PR DESCRIPTION
  - The base centos:8 image

    `sha256:5528e8b1b1719d34604c87e11dcd1c0a20bedf46e83b5632cdeac91b8c04efc1`

    comes with broken cmake package due to old libarchive (v3.3.2).
    We use that image for our build-deps:el8 image

  - libarchive v3.3.3 seems to work.

  - Once the base image is updated upstream this can be removed.