### PR TITLE
Add include/omc.

### DIFF
--- a/debian/omc-common.install
+++ b/debian/omc-common.install
@@ -1,5 +1,4 @@
 debian/tmp/usr/share/omc/*.idl
 debian/tmp/usr/share/omc/runtime
 debian/tmp/usr/lib/omc/*.mo
-debian/tmp/usr/include/omc/c
-debian/tmp/usr/include/omc/scripting-API
+debian/tmp/usr/include/omc


### PR DESCRIPTION
  - Sundials headers have been moved from `include/omc/c` to
    `include/omc`