### PR TITLE
Remove duplicate listing of omsi headers.

### DIFF
--- a/debian/libomcsimulation.install
+++ b/debian/libomcsimulation.install
@@ -27,6 +27,4 @@ debian/tmp/usr/lib/*/omc/libomopc*
 debian/tmp/usr/lib/*/omc/libsundials_*
 
 # OMSI
-
-debian/tmp/usr/include/omc/omsi/*
 debian/tmp/usr/lib/*/omc/omsi/*


### PR DESCRIPTION
  - Headers are added in `debian/omc-common.install` with `include/omc`
    being installed already.