### PR TITLE
Add sundials separately. Undo 53d4120 and 23ef91f.

### DIFF
--- a/debian/libomcsimulation.install
+++ b/debian/libomcsimulation.install
@@ -27,4 +27,5 @@ debian/tmp/usr/lib/*/omc/libomopc*
 debian/tmp/usr/lib/*/omc/libsundials_*
 
 # OMSI
+debian/tmp/usr/include/omc/omsi/*
 debian/tmp/usr/lib/*/omc/omsi/*

--- a/debian/omc-common.install
+++ b/debian/omc-common.install
@@ -1,4 +1,6 @@
 debian/tmp/usr/share/omc/*.idl
 debian/tmp/usr/share/omc/runtime
 debian/tmp/usr/lib/omc/*.mo
-debian/tmp/usr/include/omc
+debian/tmp/usr/include/omc/c
+debian/tmp/usr/include/omc/scripting-API
+debian/tmp/usr/include/omc/sundials


### PR DESCRIPTION
  - Includes are scattered in different places so for now it is easier
    to individually list sub directories in include/omc instead of
    installing include/omc as a whole in one place.