### PR TITLE
Require gcc, g++ and gfortran explicitly and fix configure flags.

### DIFF
--- a/rpm/SPECS/openmodelica.spec.tpl
+++ b/rpm/SPECS/openmodelica.spec.tpl
@@ -107,8 +107,9 @@ BuildRequires: libarchive >= 3.3.3
 # Use gcc-11 on EL8 as well. devtoolset does not seem to be available on
 # EL8. One is supposed to use gcc-toolset instead.
 %if 0%{?rhel} == 8
-Requires: gcc-toolset-11
-BuildRequires: gcc-toolset-11
+Requires: gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran
+BuildRequires: gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran
+%define devtoolsconfigureflags CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-11/root/usr/bin/g++ FC=/opt/rh/gcc-toolset-11/root/usr/bin/gfortran
 %endif
 
 # EL7 has -static-libstdc++ inside devtools (but the system g++ doesn't know the flag) -- adrpo: check this, also for el6


### PR DESCRIPTION
  - Require gcc, g++, and gfortran individually like we do for EL7. The current one might work but maybe it installs things we do not need as well.

  - Adjust configure flags to use the new compilers from `/opt/rh/gcc-toolset-11/root/usr/bin/` on EL8.