### PR TITLE
Enable the gcc-toolset-11 for EL8.

### DIFF
--- a/rpm/SPECS/openmodelica.spec.tpl
+++ b/rpm/SPECS/openmodelica.spec.tpl
@@ -160,6 +160,11 @@ PATCHCMDS
 %if 0%{?rhel} <= 7 && 0%{?rhel} >= 1
 source /opt/rh/devtoolset-11/enable
 %endif
+
+%if 0%{?rhel} == 8
+source /opt/rh/gcc-toolset-11/enable
+%endif
+
 autoreconf --install
 ./configure CFLAGS="-Os" CXXFLAGS="-Os" QTDIR=/usr/%{_lib}/qt5/ %{withomniorb} CONFIGUREFLAGS %{?devtoolsconfigureflags} --without-omc --prefix=/opt/%{name} --without-omlibrary %{cmakecommand}
 


### PR DESCRIPTION
  - The requirements were added by the previous commit but the toolset was not enabled(?). This leads to confusing issues where an older version of `as` is used with the new gcc/g++ versions.