### PR TITLE
Try setting the assembler (as) to the toolset version.

### DIFF
--- a/rpm/SPECS/openmodelica.spec.tpl
+++ b/rpm/SPECS/openmodelica.spec.tpl
@@ -109,7 +109,7 @@ BuildRequires: libarchive >= 3.3.3
 %if 0%{?rhel} == 8
 Requires: gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran
 BuildRequires: gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran
-%define devtoolsconfigureflags CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-11/root/usr/bin/g++ FC=/opt/rh/gcc-toolset-11/root/usr/bin/gfortran
+%define devtoolsconfigureflags CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-11/root/usr/bin/g++ FC=/opt/rh/gcc-toolset-11/root/usr/bin/gfortran AS=/opt/rh/gcc-toolset-11/root/usr/bin/as
 %endif
 
 # EL7 has -static-libstdc++ inside devtools (but the system g++ doesn't know the flag) -- adrpo: check this, also for el6


### PR DESCRIPTION
  - ON EL8 we have an issue where we sometimes pick up the wrong gcc/g++ and then fail due `as` issues when CMake checks the compilers.

    Right now this is happening when configuring Ipopt. CMake finds the new Fortran but tries to use the old AS because it is given an old gcc version. While the issue should be fixed in OpenModelica itself, for now try setting AS explicitly to get the Linux packages up and running again.