### PR TITLE
Add CMake to dependencies of omc Debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,6 +75,7 @@ Package: omc
 Section: math
 Architecture: any
 Depends: clang,
+ cmake,
  build-essential,
  libexpat1-dev,
  liblapack-dev,


### PR DESCRIPTION
## Changes

  - CMake is needed to build FMUs with the default settings of omc.
    Adding CMake to dependencies of Debian package `omc`.

## Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11554#issuecomment-1836339711