### PR TITLE
debian: fix libtbb install glob after oneTBB upgrade

### DIFF
--- a/debian/libomcsimulation.install
+++ b/debian/libomcsimulation.install
@@ -43,4 +43,4 @@ debian/tmp/usr/lib/*/omc/omsi/*
 
 # ParModAuto
 debian/tmp/usr/lib/*/omc/libParModelicaAuto.*
-debian/tmp/usr/lib/*/omc/libtbb_static.*
+debian/tmp/usr/lib/*/omc/libtbb*


### PR DESCRIPTION
The tbb -> oneTBB 2023.0.0 upgrade renamed the installed static library from libtbb_static.a (old wjakob/Intel TBB 2020.2 fork) to libtbb.a (oneTBB's default target output name). The libomcsimulation.install glob still referenced libtbb_static.*, so dh_install aborted with:

  Cannot find (any matches for) "debian/tmp/usr/lib/*/omc/libtbb_static.*"

Widen the glob to libtbb* so it matches the current static archive and stays robust whether oneTBB is built static or shared in the future.